### PR TITLE
Best score refactor take home

### DIFF
--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -40,7 +40,7 @@ class YahtzeeScoring
     return score_large_straight if large_straight?
     return score_small_straight if small_straight?
 
-    score_full_house(roll)
+    update_score(:full_house, 25) if full_house?
     score_four_of_a_kind(roll)
     score_three_of_a_kind(roll)
     score_upper_section(roll)
@@ -91,12 +91,6 @@ class YahtzeeScoring
     roll.each do |num|
       update_score(:four_of_a_kind, @roll_total) if roll.count(num) >= 4
     end
-  end
-
-  def score_full_house(roll)
-    counts = roll.tally.values.sort
-    update_score(:full_house, 25) if full_house?
-    { category: nil, score: 0 }
   end
 
   def score_chance

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -1,19 +1,15 @@
 class YahtzeeScoring
-  attr_reader :roll, :tally, :best_score, :best_category
-
-  NUM_TO_CATEGORY = [:zero, :one, :two, :three, :four, :five, :six]
+  NUM_TO_CATEGORY = [:one, :two, :three, :four, :five, :six]
   STRAIGHTS = {
     small: [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]],
     large: [[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]
   }
 
   def initialize(roll)
-    @roll = roll
     @tally = roll.tally
     @roll_total = roll.sum
     @unique_sorted = @tally.keys.sort
     @sorted_tallies = @tally.values.sort
-    @max_tally = @sorted_tallies.last
 
     @best_score = 0
     @best_category = nil

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -1,6 +1,7 @@
 class YahtzeeScoring
   attr_reader :roll, :tally, :best_score, :best_category
 
+  NUM_TO_CATEGORY = [:zero, :one, :two, :three, :four, :five, :six]
   STRAIGHTS = {
     small: [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]],
     large: [[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]
@@ -19,41 +20,26 @@ class YahtzeeScoring
   end
   
   def self.best_score(roll)
-    new(roll).score_lower_section(roll)
+    new(roll).score_lower_section
   end
 
-  def score_upper_section(roll)
-    best_category = nil
-    best_score = 0
-
-    (1..6).each do |num|
-      score = roll.count(num) * num
-      update_score(num_to_category(num), score)  
-    end
-    { category: best_category, score: best_score }
-  end
-
-  def num_to_category(num)
-    { 1 => :ones, 2 => :twos, 3 => :threes, 4 => :fours, 5 => :fives, 6 => :sixes }[num]
-  end
-
-  def score_lower_section(roll)
+  def score_lower_section
     return score_yahtzee if yahtzee?
     return score_large_straight if large_straight?
     return score_small_straight if small_straight?
 
     update_score(:full_house, 25) if full_house?
     update_score(:four_of_a_kind, @roll_total) if four_of_a_kind?
-    score_three_of_a_kind(roll)
-    score_upper_section(roll)
+    update_score(:three_of_a_kind, @roll_total) if three_of_a_kind?
     score_chance
+    score_upper_section
     high_score
   end
 
-  def score_three_of_a_kind(roll)
-    roll.each do |num|
-      update_score(:three_of_a_kind, @roll_total) if roll.count(num) >= 3
-    end
+  private
+
+  def score_upper_section
+    @tally.each { |num, count| update_score(NUM_TO_CATEGORY[num - 1], num * count) }
   end
 
   def yahtzee?
@@ -91,6 +77,10 @@ class YahtzeeScoring
 
   def four_of_a_kind?
     @max_tally >= 4
+  end
+
+  def three_of_a_kind?
+    @max_tally >= 3
   end
 
   def score_chance

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -1,21 +1,9 @@
 class YahtzeeScoring
   def self.best_score(roll)
-    best_category = nil
-    best_score = 0
+    score_upper = score_upper_section(roll)
+    score_lower = score_lower_section(roll)
 
-    score = score_upper_section(roll)
-    if score[:score] > best_score
-      best_score = score[:score]
-      best_category = score[:category]
-    end
-
-    score = score_lower_section(roll)
-    if score[:score] > best_score
-      best_score = score[:score]
-      best_category = score[:category]
-    end
-
-    { category: best_category, score: best_score }
+    score_upper > score_lower ? score_upper : score_lower
   end
 
   def self.score_upper_section(roll)

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -41,12 +41,12 @@ class YahtzeeScoring
   def score_lower_section(roll)
     return score_yahtzee if yahtzee?
     return score_large_straight if large_straight?
+    return score_small_straight if small_straight?
 
     categories = [
       score_three_of_a_kind(roll),
       score_four_of_a_kind(roll),
       score_full_house(roll),
-      score_small_straight(roll),
       score_chance(roll),
       score_upper_section(roll)
     ].max_by { |hash| hash[:score] }
@@ -76,7 +76,17 @@ class YahtzeeScoring
   def score_large_straight
     update_score(:large_straight, 40)
     high_score
-  end 
+  end
+
+  def small_straight?
+    STRAIGHTS[:small].include?(@unique_sorted)
+  end
+
+  def score_small_straight
+    return unless @tally.size >= 4
+    update_score(:small_straight, 30)
+    high_score
+  end
 
   def score_four_of_a_kind(roll)
     roll.each do |num|
@@ -88,13 +98,6 @@ class YahtzeeScoring
   def score_full_house(roll)
     counts = roll.tally.values.sort
     return { category: :full_house, score: 25 } if counts == [2, 3]
-    { category: nil, score: 0 }
-  end
-
-  def score_small_straight(roll)
-    unique_sorted = roll.uniq.sort
-    straights = [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
-    return { category: :small_straight, score: 30 } if straights.any? { |s| (s - unique_sorted).empty? }
     { category: nil, score: 0 }
   end
 

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -1,9 +1,17 @@
 class YahtzeeScoring
-  def self.best_score(roll)
-    score_upper = score_upper_section(roll)
-    score_lower = score_lower_section(roll)
+  attr_reader :roll, :tally, :best_score, :best_category
 
-    score_upper > score_lower ? score_upper : score_lower
+  def initialize(roll)
+    @tally = roll.tally
+    @roll_total = roll.sum
+
+    @best_score = 0
+    @best_category = nil
+  end
+  
+  def self.best_score(roll)
+    new(roll)
+    score_lower_section(roll)
   end
 
   def self.score_upper_section(roll)
@@ -35,7 +43,8 @@ class YahtzeeScoring
       score_small_straight(roll),
       score_large_straight(roll),
       score_yahtzee(roll),
-      score_chance(roll)
+      score_chance(roll),
+      score_upper_section(roll)
     ]
 
     categories.each do |result|

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -26,10 +26,7 @@ class YahtzeeScoring
 
     (1..6).each do |num|
       score = roll.count(num) * num
-      if score > best_score
-        best_score = score
-        best_category = num_to_category(num)
-      end
+      update_score(num_to_category(num), score)  
     end
     { category: best_category, score: best_score }
   end
@@ -43,20 +40,18 @@ class YahtzeeScoring
     return score_large_straight if large_straight?
     return score_small_straight if small_straight?
 
-    categories = [
-      score_three_of_a_kind(roll),
-      score_four_of_a_kind(roll),
-      score_full_house(roll),
-      score_chance(roll),
-      score_upper_section(roll)
-    ].max_by { |hash| hash[:score] }
+    score_full_house(roll)
+    score_four_of_a_kind(roll)
+    score_three_of_a_kind(roll)
+    score_upper_section(roll)
+    score_chance
+    high_score
   end
 
   def score_three_of_a_kind(roll)
     roll.each do |num|
-      return { category: :three_of_a_kind, score: roll.sum } if roll.count(num) >= 3
+      update_score(:three_of_a_kind, @roll_total) if roll.count(num) >= 3
     end
-    { category: nil, score: 0 }
   end
 
   def yahtzee?
@@ -88,21 +83,24 @@ class YahtzeeScoring
     high_score
   end
 
+  def full_house?
+    @sorted_tallies == [2, 3]
+  end
+
   def score_four_of_a_kind(roll)
     roll.each do |num|
-      return { category: :four_of_a_kind, score: roll.sum } if roll.count(num) >= 4
+      update_score(:four_of_a_kind, @roll_total) if roll.count(num) >= 4
     end
-    { category: nil, score: 0 }
   end
 
   def score_full_house(roll)
     counts = roll.tally.values.sort
-    return { category: :full_house, score: 25 } if counts == [2, 3]
+    update_score(:full_house, 25) if full_house?
     { category: nil, score: 0 }
   end
 
-  def score_chance(roll)
-    { category: :chance, score: roll.sum }
+  def score_chance
+    update_score(:chance, @roll_total)
   end
 
   def update_score(category, score)

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -11,11 +11,10 @@ class YahtzeeScoring
   end
   
   def self.best_score(roll)
-    new(roll)
-    score_lower_section(roll)
+    new(roll).score_lower_section(roll)
   end
 
-  def self.score_upper_section(roll)
+  def score_upper_section(roll)
     best_category = nil
     best_score = 0
 
@@ -29,62 +28,67 @@ class YahtzeeScoring
     { category: best_category, score: best_score }
   end
 
-  def self.num_to_category(num)
+  def num_to_category(num)
     { 1 => :ones, 2 => :twos, 3 => :threes, 4 => :fours, 5 => :fives, 6 => :sixes }[num]
   end
 
-  def self.score_lower_section(roll)
+  def score_lower_section(roll)
+    return score_yahtzee if yahtzee?
+
     categories = [
       score_three_of_a_kind(roll),
       score_four_of_a_kind(roll),
       score_full_house(roll),
       score_small_straight(roll),
       score_large_straight(roll),
-      score_yahtzee(roll),
       score_chance(roll),
       score_upper_section(roll)
     ].max_by { |hash| hash[:score] }
   end
 
-  def self.score_three_of_a_kind(roll)
+  def score_three_of_a_kind(roll)
     roll.each do |num|
       return { category: :three_of_a_kind, score: roll.sum } if roll.count(num) >= 3
     end
     { category: nil, score: 0 }
   end
 
-  def self.score_four_of_a_kind(roll)
+  def yahtzee?
+    @tally.size == 1
+  end
+
+  def score_yahtzee
+    update_score(:yahtzee, 50)
+    high_score
+  end
+
+  def score_four_of_a_kind(roll)
     roll.each do |num|
       return { category: :four_of_a_kind, score: roll.sum } if roll.count(num) >= 4
     end
     { category: nil, score: 0 }
   end
 
-  def self.score_full_house(roll)
+  def score_full_house(roll)
     counts = roll.tally.values.sort
     return { category: :full_house, score: 25 } if counts == [2, 3]
     { category: nil, score: 0 }
   end
 
-  def self.score_small_straight(roll)
+  def score_small_straight(roll)
     unique_sorted = roll.uniq.sort
     straights = [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
     return { category: :small_straight, score: 30 } if straights.any? { |s| (s - unique_sorted).empty? }
     { category: nil, score: 0 }
   end
 
-  def self.score_large_straight(roll)
+  def score_large_straight(roll)
     unique_sorted = roll.uniq.sort
     return { category: :large_straight, score: 40 } if unique_sorted == [1, 2, 3, 4, 5] || unique_sorted == [2, 3, 4, 5, 6]
     { category: nil, score: 0 }
   end
 
-  def self.score_yahtzee(roll)
-    return { category: :yahtzee, score: 50 } if roll.uniq.length == 1
-    { category: nil, score: 0 }
-  end
-
-  def self.score_chance(roll)
+  def score_chance(roll)
     { category: :chance, score: roll.sum }
   end
 
@@ -93,5 +97,9 @@ class YahtzeeScoring
 
     @best_score = score
     @best_category = category
+  end
+
+  def high_score
+    { category: @best_category, score: @best_score }
   end
 end

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -1,10 +1,16 @@
 class YahtzeeScoring
   attr_reader :roll, :tally, :best_score, :best_category
 
+  STRAIGHTS = {
+    small: [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]],
+    large: [[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]]
+  }
+
   def initialize(roll)
     @roll = roll
     @tally = roll.tally
     @roll_total = roll.sum
+    @unique_sorted = @tally.keys.sort
 
     @best_score = 0
     @best_category = nil
@@ -34,13 +40,13 @@ class YahtzeeScoring
 
   def score_lower_section(roll)
     return score_yahtzee if yahtzee?
+    return score_large_straight if large_straight?
 
     categories = [
       score_three_of_a_kind(roll),
       score_four_of_a_kind(roll),
       score_full_house(roll),
       score_small_straight(roll),
-      score_large_straight(roll),
       score_chance(roll),
       score_upper_section(roll)
     ].max_by { |hash| hash[:score] }
@@ -62,6 +68,16 @@ class YahtzeeScoring
     high_score
   end
 
+  def large_straight?
+    return unless @tally.size == 5
+    STRAIGHTS[:large].include?(@unique_sorted)
+  end
+
+  def score_large_straight
+    update_score(:large_straight, 40)
+    high_score
+  end 
+
   def score_four_of_a_kind(roll)
     roll.each do |num|
       return { category: :four_of_a_kind, score: roll.sum } if roll.count(num) >= 4
@@ -79,12 +95,6 @@ class YahtzeeScoring
     unique_sorted = roll.uniq.sort
     straights = [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
     return { category: :small_straight, score: 30 } if straights.any? { |s| (s - unique_sorted).empty? }
-    { category: nil, score: 0 }
-  end
-
-  def score_large_straight(roll)
-    unique_sorted = roll.uniq.sort
-    return { category: :large_straight, score: 40 } if unique_sorted == [1, 2, 3, 4, 5] || unique_sorted == [2, 3, 4, 5, 6]
     { category: nil, score: 0 }
   end
 

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -11,6 +11,8 @@ class YahtzeeScoring
     @tally = roll.tally
     @roll_total = roll.sum
     @unique_sorted = @tally.keys.sort
+    @sorted_tallies = @tally.values.sort
+    @max_tally = @sorted_tallies.last
 
     @best_score = 0
     @best_category = nil
@@ -41,7 +43,7 @@ class YahtzeeScoring
     return score_small_straight if small_straight?
 
     update_score(:full_house, 25) if full_house?
-    score_four_of_a_kind(roll)
+    update_score(:four_of_a_kind, @roll_total) if four_of_a_kind?
     score_three_of_a_kind(roll)
     score_upper_section(roll)
     score_chance
@@ -87,10 +89,8 @@ class YahtzeeScoring
     @sorted_tallies == [2, 3]
   end
 
-  def score_four_of_a_kind(roll)
-    roll.each do |num|
-      update_score(:four_of_a_kind, @roll_total) if roll.count(num) >= 4
-    end
+  def four_of_a_kind?
+    @max_tally >= 4
   end
 
   def score_chance

--- a/yahtzee_scoring.rb
+++ b/yahtzee_scoring.rb
@@ -2,6 +2,7 @@ class YahtzeeScoring
   attr_reader :roll, :tally, :best_score, :best_category
 
   def initialize(roll)
+    @roll = roll
     @tally = roll.tally
     @roll_total = roll.sum
 
@@ -33,9 +34,6 @@ class YahtzeeScoring
   end
 
   def self.score_lower_section(roll)
-    best_category = nil
-    best_score = 0
-
     categories = [
       score_three_of_a_kind(roll),
       score_four_of_a_kind(roll),
@@ -45,16 +43,7 @@ class YahtzeeScoring
       score_yahtzee(roll),
       score_chance(roll),
       score_upper_section(roll)
-    ]
-
-    categories.each do |result|
-      if result[:score] > best_score
-        best_score = result[:score]
-        best_category = result[:category]
-      end
-    end
-
-    { category: best_category, score: best_score }
+    ].max_by { |hash| hash[:score] }
   end
 
   def self.score_three_of_a_kind(roll)
@@ -97,5 +86,12 @@ class YahtzeeScoring
 
   def self.score_chance(roll)
     { category: :chance, score: roll.sum }
+  end
+
+  def update_score(category, score)
+    return if score <= @best_score
+
+    @best_score = score
+    @best_category = category
   end
 end

--- a/yahtzee_scoring_test.rb
+++ b/yahtzee_scoring_test.rb
@@ -8,12 +8,66 @@ class TestYahtzeeScoring < Minitest::Test
     @rolls = Array.new(100_000) { Array.new(5) { rand(1..6) } }
   end
 
-  def test_best_score
+  #Best Score
+  #Yahtzee
+  def test_best_score_yahtzee
     assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([6, 6, 6, 6, 6]))
+  end
+
+  def test_best_score_yahtzee_low
+    assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([1, 1, 1, 1, 1]))
+  end
+
+  #Large Straight
+  def test_best_score_large_straight1
     assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([2, 3, 4, 5, 6]))
+  end
+
+  def test_best_score_large_straight2
+    assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([2, 3, 4, 5, 1]))
+  end
+
+  #Small Straight
+  def test_best_score_small_straight1
+    assert_equal({ category: :small_straight, score: 30 }, YahtzeeScoring.best_score([2, 3, 4, 5, 5]))
+  end
+
+  def test_best_score_small_straight2
+    assert_equal({ category: :small_straight, score: 30 }, YahtzeeScoring.best_score([2, 4, 3, 2, 1]))
+  end
+
+  def test_best_score_small_straight3
+    assert_equal({ category: :small_straight, score: 30 }, YahtzeeScoring.best_score([6, 4, 3, 5, 6]))
+  end
+  
+  #Four of a Kind
+  def test_best_score_three_of_a_kind
+    assert_equal({ category: :four_of_a_kind, score: 21 }, YahtzeeScoring.best_score([2, 2, 2, 2, 1]))
+  end
+
+  #Three of a Kind
+  def test_best_score_three_of_a_kind
     assert_equal({ category: :three_of_a_kind, score: 21 }, YahtzeeScoring.best_score([6, 6, 6, 2, 1]))
+  end
+
+  def test_best_score_three_of_a_kind
+    assert_equal({ category: :three_of_a_kind, score: 15 }, YahtzeeScoring.best_score([4, 4, 4, 2, 1]))
+  end
+  
+  #Full House
+  def test_best_score_full_house
     assert_equal({ category: :full_house, score: 25 }, YahtzeeScoring.best_score([3, 3, 3, 5, 5]))
+  end
+
+  #Chance
+  def test_best_score_chance
     assert_equal({ category: :chance, score: 17 }, YahtzeeScoring.best_score([1, 2, 3, 5, 6]))
+  end
+
+  #Edgecases
+  #Could be three of a kind, chance, or full house
+  def test_three_of_a_kind_vs_three_of_a_kind
+    assert_equal({ category: :three_of_a_kind, score: 28 }, YahtzeeScoring.best_score([5, 5, 6, 6, 6]))
   end
 
   def test_benchmark

--- a/yahtzee_scoring_test.rb
+++ b/yahtzee_scoring_test.rb
@@ -1,12 +1,28 @@
 require "minitest/autorun"
 require_relative "yahtzee_scoring"
+require 'logger'
+require 'benchmark'
 
 class TestYahtzeeScoring < Minitest::Test
+  def setup
+    @rolls = Array.new(100_000) { Array.new(5) { rand(1..6) } }
+  end
+
   def test_best_score
     assert_equal({ category: :yahtzee, score: 50 }, YahtzeeScoring.best_score([6, 6, 6, 6, 6]))
     assert_equal({ category: :large_straight, score: 40 }, YahtzeeScoring.best_score([2, 3, 4, 5, 6]))
     assert_equal({ category: :three_of_a_kind, score: 21 }, YahtzeeScoring.best_score([6, 6, 6, 2, 1]))
     assert_equal({ category: :full_house, score: 25 }, YahtzeeScoring.best_score([3, 3, 3, 5, 5]))
     assert_equal({ category: :chance, score: 17 }, YahtzeeScoring.best_score([1, 2, 3, 5, 6]))
+  end
+
+  def test_benchmark
+    execution_time = Benchmark.realtime do
+      @rolls.each { |roll| YahtzeeScoring.best_score(roll) }
+    end
+
+    puts "\nExecution Time: #{execution_time.round(5)} seconds"
+
+    assert_operator execution_time, :<, 0.7, "Performance regression detected!"
   end
 end


### PR DESCRIPTION
Yahtzee Scoring Kata – Refactored for Performance & Readability

I implemented the Yahtzee scoring system by splitting the logic into upper and lower sections. Key values like the dice tally, total, and sorted unique values are cached during initialization to avoid redundant calculations. I added guard clauses in the lower-section scoring to short-circuit when a top score (Yahtzee, large straight, or small straight) is detected. These changes reduced the benchmark time from 0.55221s to 0.19581s. Overall, the code is now more readable, maintainable, and fully tested.